### PR TITLE
Add files via upload

### DIFF
--- a/src/MAX6675_Thermocouple.cpp
+++ b/src/MAX6675_Thermocouple.cpp
@@ -29,6 +29,19 @@ double MAX6675_Thermocouple::readCelsius() {
 	return (value * 0.25);
 }
 
+double MAX6675_Thermocouple::FastReadCelsius() {
+	digitalWrite(this->CS_pin, LOW);
+	delayMicroseconds(1);
+	int value = FastSpiRead();
+	value <<= 8;
+	value |= FastSpiRead();
+	digitalWrite(this->CS_pin, HIGH);
+	if (value & 0x4) {
+		return NAN;
+	}
+	value >>= 3;
+	return (value * 0.25);
+}
 /**
 	Returns a temperature in Kelvin.
 	Reads the temperature in Celsius,
@@ -61,6 +74,20 @@ byte MAX6675_Thermocouple::spiread() {
 		}
 		digitalWrite(this->SCK_pin, HIGH);
 		delay(1);
+	}
+	return value;
+}
+
+byte MAX6675_Thermocouple::FastSpiRead() {
+	byte value = 0;
+	for (int i = 7; i >= 0; --i) {
+		digitalWrite(this->SCK_pin, LOW);
+		delayMicroseconds(1);
+		if (digitalRead(this->SO_pin)) {
+			value |= (1 << i);
+		}
+		digitalWrite(this->SCK_pin, HIGH);
+		delayMicroseconds(1);
 	}
 	return value;
 }

--- a/src/MAX6675_Thermocouple.h
+++ b/src/MAX6675_Thermocouple.h
@@ -68,7 +68,15 @@ class MAX6675_Thermocouple final : public Thermocouple {
 			NAN if no thermocouple attached
 		*/
 		double readCelsius();
+		
+		/**
+			Reads a temperature in Celsius from the thermocouple.
 
+			@return temperature in degree Celsius or
+			NAN if no thermocouple attached
+		*/
+		double FastReadCelsius();
+		
 		/**
 			Reads a temperature in Kelvin from the thermocouple.
 
@@ -87,6 +95,8 @@ class MAX6675_Thermocouple final : public Thermocouple {
 
 	private:
 		byte spiread();
+		
+		byte FastSpiRead();
 
 		/**
 			Celsius to Kelvin conversion:

--- a/src/SerialFastReading.ino
+++ b/src/SerialFastReading.ino
@@ -1,0 +1,69 @@
+/*
+  Average Thermocouple
+
+  Reads a temperature from a thermocouple based
+  on the MAX6675 driver and displays it in the default Serial.
+
+  https://github.com/YuriiSalimov/MAX6675_Thermocouple
+
+  Created by Yurii Salimov, May, 2019.
+  Released into the public domain.
+*/
+#include <Thermocouple.h>
+#include <MAX6675_Thermocouple.h>
+/*
+#define SCK_PIN 3
+#define CS_PIN 4
+#define SO_PIN 5
+*/
+#define SCK_PIN 13
+#define CS_PIN 10
+#define SO_PIN 12
+
+double starttime_ms, conversiontime_ms, starttime_us, conversiontime_us;
+
+Thermocouple* thermocouple;
+
+// the setup function runs once when you press reset or power the board
+void setup() {
+  Serial.begin(115200);
+
+  thermocouple = new MAX6675_Thermocouple(SCK_PIN, CS_PIN, SO_PIN);
+}
+
+// the loop function runs over and over again forever
+void loop() {
+  // Reads temperature
+
+  // Read Temperature original timing ( delay in msec. )
+  starttime_ms = millis();
+  const double celsius = thermocouple->readCelsius();
+  conversiontime_ms = millis() - starttime_ms;
+
+  // Read Temperature original timing ( delay in usec. )
+  starttime_us = micros();
+  const double celsius_fast = thermocouple->FastReadCelsius();
+  conversiontime_us = micros() - starttime_us;
+
+  const double kelvin = thermocouple->readKelvin();
+  const double fahrenheit = thermocouple->readFahrenheit();
+
+  // Output of information
+  Serial.print("Temperature: ");
+  Serial.print(celsius);
+  Serial.print(" C, ");
+  Serial.print(kelvin);
+  Serial.print(" K, ");
+  Serial.print(fahrenheit);
+  Serial.print(" F ");
+  Serial.print("Convertiontime : ");
+  Serial.print(conversiontime_ms);
+  Serial.print(" msec.");
+  Serial.print("|| Fast Version : ");
+  Serial.print(celsius_fast);
+  Serial.print(" C, ");
+  Serial.print(conversiontime_us);
+  Serial.println(" usec.");
+  
+  delay(500); // optionally, only to delay the output of information in the example.
+}

--- a/src/Thermocouple.h
+++ b/src/Thermocouple.h
@@ -38,6 +38,13 @@ class Thermocouple {
 			@return temperature in degree Celsius
 		*/
 		virtual double readCelsius() = 0;
+		
+		/**
+			Reads a temperature in Celsius from the thermocouple in fast mode.
+
+			@return temperature in degree Celsius
+		*/
+		virtual double FastReadCelsius() = 0;
 
 		/**
 			Reads a temperature in Kelvin from the thermocouple.

--- a/src/keywords.txt
+++ b/src/keywords.txt
@@ -1,0 +1,22 @@
+######################################
+#        Syntax Coloring Map         #
+#      For MAX6675_Thermocouple      #
+######################################
+
+######################################
+#       Data types (KEYWORD1)        #
+######################################
+
+Thermocouple	KEYWORD1
+MAX6675_Thermocouple	KEYWORD1
+AverageThermocouple	KEYWORD1
+SmoothThermocouple	KEYWORD1
+
+######################################
+#  Methods and Functions (KEYWORD2)  #
+######################################
+
+readCelsius	KEYWORD2
+readKelvin	KEYWORD2
+readFahrenheit	KEYWORD2
+FastReadCelsius KEYWORD2


### PR DESCRIPTION
MAX6675 supports an SCK up to 4.3 MHz. This means that the minimum duration of an SCK clock can be 200ns. 
I integrated the following methods into the library to reduce reading time from the MAX6675:
- FastReadCelcius ()
- FastSpiRead ()
With the use of this routine the reading times are reduced from about 33 ms. to about 250 us, 
therefore reducing this phase of about 130 times.